### PR TITLE
Added CSV mixin to wrap `ripe-commons-js`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-*
+* Add CSV mixin to wrap `ripe-commons-js` functions - [ripe-pulse/#302](https://github.com/ripe-tech/ripe-pulse/issues/302)
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "webpack": "webpack --config webpack.config.js"
     },
     "dependencies": {
+        "ripe-commons": "^0.8.1",
         "vue": "^2.6.14",
         "vue-global-events": "^1.2.1",
         "vuex": "^3.6.2",

--- a/vue/mixins/csv.js
+++ b/vue/mixins/csv.js
@@ -1,0 +1,24 @@
+import { arrayListToCsv, arrayToCsv, objectListToCsv, objectToCsv, parseCsv, parseCsvFile } from "ripe-commons";
+
+export const csvMixin = {
+    methods: {
+        arrayListToCsv(data, headers = [], delimiter = ",") {
+            return arrayListToCsv(data, headers, delimiter);
+        },
+        arrayToCsv(data, delimiter = ",") {
+            return arrayToCsv(data, delimiter);
+        },
+        objectListToCsv(data, headers = [], delimiter = ",") {
+            return objectListToCsv(data, headers, delimiter);
+        },
+        objectToCsv(data, headers = [], delimiter = ",") {
+            return objectToCsv(data, headers, delimiter);
+        },
+        parseCsv(dataS, object = false, sanitize = true, delimiter = ",") {
+            return parseCsv(dataS, object, sanitize, delimiter);
+        },
+        parseCsvFile(file, parser = null) {
+            return parseCsvFile(file, parser);
+        }
+    }
+};

--- a/vue/mixins/csv.js
+++ b/vue/mixins/csv.js
@@ -1,4 +1,11 @@
-import { arrayListToCsv, arrayToCsv, objectListToCsv, objectToCsv, parseCsv, parseCsvFile } from "ripe-commons";
+import {
+    arrayListToCsv,
+    arrayToCsv,
+    objectListToCsv,
+    objectToCsv,
+    parseCsv,
+    parseCsvFile
+} from "ripe-commons";
 
 export const csvMixin = {
     methods: {

--- a/vue/mixins/index.js
+++ b/vue/mixins/index.js
@@ -1,2 +1,3 @@
+export * from "./csv";
 export * from "./locale";
 export * from "./utils";


### PR DESCRIPTION
| - | - |
| --- | --- |
| Issue | Related to [#302](https://github.com/ripe-tech/ripe-pulse/issues/302) |
| Dependencies | https://github.com/ripe-tech/ripe-commons-js/pull/33, https://github.com/ripe-tech/ripe-commons-js/pull/35 |
| Decisions | Some functions were extracted from `ripe-util-vue`, but a mixing would be useful to wrap them neatly. This PR adds a new mixin to handle that. |
